### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,13 +28,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[test]'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,34 +21,21 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Set up env for CodeClimate (push)
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,13 +27,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[test]'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,34 +20,21 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.x]  # crons should always run latest python hence 3.x
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Run all tests
         run: python -m pytest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,13 +27,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[doc]'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,35 +20,21 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-
       - name: Install package
-        run: pip install '.[doc]'
+        run: python -m pip install '.[doc]'
 
       - name: Build documentation
         run: python -m sphinx -b html doc ./doc_build -d ./doc_build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'pip'
 
       - name: Upgrade pip, setuptools, wheel, build and twine
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Get full Python version
         id: full-python-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools, wheel, build and twine
-        run: python -m pip install --upgrade pip setuptools wheel build twine
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools, wheel, build and twine
+        run: python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Build and check build
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-        run: python -m pip install --upgrade pip setuptools wheel build twine
+
+      - name: Upgrade pip, setuptools, wheel, build and twine
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,44 +20,28 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel build twine
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel build twine
 
       - name: Build and check build
         run: |
           python -m build
           twine check dist/*
 
-      - name: Build and publish
+      - name: Publish
         if: ${{ success() }}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python -m build
-          twine check dist/*
           twine upload dist/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Upgrade pip, setuptools and wheel
         run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
+          cache-dependency-path: '**/setup.py'
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+
+      - name: Upgrade pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Install package
         run: python -m pip install '.[test]'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,35 +19,21 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: Get full Python version
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: pip --version >/dev/null 2>&1 || rm -rf .venv
-
-      - name: Upgrade pip, setuptools and wheel
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
       - name: Install package
-        run: pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Run basic tests
         run: python -m pytest


### PR DESCRIPTION
Update to the CI workflows making use of the newer versions of certain official worflows.

- Caching and cache management left to the setup-python action
- Properly call pip as module everywhere
- Do not run the build (and build check) twice in the publish repo