### PR TITLE
Fix typehints

### DIFF
--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -106,7 +106,8 @@ class Definition:
     format_string: Optional[str] = None
 
     def __post_init__(self):
-        # Fix types (probably strings from reading files) by using the type-hints:
+        # Fix types (probably strings from reading files) by using the type-hints
+        # this only works for native types, not the ones from typing.
         for field in fields(self):
             value = getattr(self, field.name)
             hinted_type = field.type
@@ -115,7 +116,7 @@ class Definition:
                     continue
 
                 if isinstance(value, str) and value.lower() == "none":
-                    # The key should have been skipped when writing, but you never know
+                    # The key should have been skipped when writing, but to be safe
                     LOGGER.debug(f"'None' found in {field.name}.")
                     setattr(self, field.name, None)
                     continue
@@ -124,12 +125,13 @@ class Definition:
                 hinted_type = next(t for t in hinted_type.__args__
                                    if not isinstance(t, type(None)))
 
-            if isinstance(value, hinted_type):  # all is fine
+            if isinstance(value, hinted_type):
+                # all is fine
                 continue
 
             LOGGER.debug(f"converting {field.name}: "
                          f"{type(value).__name__} -> {hinted_type.__name__}")
-            setattr(self, field.name, hinted_type(getattr(self, field.name)))
+            setattr(self, field.name, hinted_type(value))
 
     def __repr__(self):
         return f"<SDDS {self.__class__.__name__} '{self.name}'>"

--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -109,8 +109,8 @@ class Definition:
         # Fix types (probably strings from reading files) by using the type-hints:
         for field in fields(self):
             value = getattr(self, field.name)
-            type_hint = field.type
-            if hasattr(type_hint, "__args__"):  # For the Optional[...] types
+            hinted_type = field.type
+            if hasattr(hinted_type, "__args__"):  # For the Optional[...] types
                 if value is None:
                     continue
 
@@ -121,15 +121,15 @@ class Definition:
                     continue
 
                 # find the proper type from type-hint:
-                type_hint = next(t for t in type_hint.__args__
-                                 if not isinstance(t, type(None)))
+                hinted_type = next(t for t in hinted_type.__args__
+                                   if not isinstance(t, type(None)))
 
-            if isinstance(value, type_hint):  # all is fine
+            if isinstance(value, hinted_type):  # all is fine
                 continue
 
             LOGGER.debug(f"converting {field.name}: "
-                         f"{type(value).__name__} -> {type_hint.__name__}")
-            setattr(self, field.name, type_hint(getattr(self, field.name)))
+                         f"{type(value).__name__} -> {hinted_type.__name__}")
+            setattr(self, field.name, hinted_type(getattr(self, field.name)))
 
     def __repr__(self):
         return f"<SDDS {self.__class__.__name__} '{self.name}'>"

--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -52,8 +52,8 @@ class Description:
     frequently, the contents field is used to record the name of the program that created or most
     recently modified the file.
     """
-    text: Optional[str]
-    contents: Optional[str]
+    text: Optional[str] = None
+    contents: Optional[str] = None
     TAG: ClassVar[str] = "&description"
 
     def __repr__(self):
@@ -177,9 +177,9 @@ class Array(Definition):
     elements). The optional dimensions field gives the number of dimensions in the array.
     """
     TAG: ClassVar[str] = "&array"
-    field_length: int = 0
+    field_length: Optional[int] = None
     group_name: Optional[str] = None
-    dimensions: int = 1
+    dimensions: Optional[int] = None
 
 
 @dataclass

--- a/sdds/reader.py
+++ b/sdds/reader.py
@@ -144,10 +144,9 @@ def _read_bin_array(inbytes: IO[bytes], definition: Array, endianness: str) -> A
     dims, total_len = _read_bin_array_len(inbytes, definition.dimensions, endianness)
 
     if definition.type == "string":
-        len_type: str = "long"\
-                        if not hasattr(definition, "modifier")\
-                        else {"u1": "char", "i2": "short"}\
-                             .get(definition.modifier, "long")
+        len_type = {"u1": "char", "i2": "short"}.get(
+            getattr(definition, "modifier", None), "long"
+        )
         str_array = []
         for _ in range(total_len):
             str_len = int(_read_bin_numeric(inbytes, len_type, 1, endianness))

--- a/sdds/reader.py
+++ b/sdds/reader.py
@@ -62,7 +62,7 @@ def _read_header(inbytes: IO[bytes]) -> Tuple[str, List[Definition], Optional[De
                 Column.TAG: Column,
                 Parameter.TAG: Parameter,
                 Array.TAG: Array}[word](name=def_dict.pop("name"),
-                                        type_=def_dict.pop("type"),
+                                        type=def_dict.pop("type"),
                                         **def_dict))
             continue
         if word == Description.TAG:

--- a/sdds/reader.py
+++ b/sdds/reader.py
@@ -158,7 +158,10 @@ def _read_bin_array(inbytes: IO[bytes], definition: Array, endianness: str) -> A
     return data.reshape(dims)
 
 
-def _read_bin_array_len(inbytes: IO[bytes], num_dims: int, endianness: str) -> Tuple[List[int], int]:
+def _read_bin_array_len(inbytes: IO[bytes], num_dims: Optional[int], endianness: str) -> Tuple[List[int], int]:
+    if num_dims is None:
+        num_dims = 1
+
     dims = [_read_bin_int(inbytes, endianness) for _ in range(num_dims)]
     return dims, int(np.prod(dims))
 

--- a/sdds/writer.py
+++ b/sdds/writer.py
@@ -46,7 +46,7 @@ def _write_header(sdds_file: SddsFile, outbytes: IO[bytes]) -> List[str]:
 
 def _sdds_def_as_str(definition: Union[Description, Definition, Data]) -> str:
     start = definition.TAG + " "
-    field_values = {field.name: getattr(definition, field.name)for field in fields(definition)}
+    field_values = {field.name: getattr(definition, field.name) for field in fields(definition)}
     kv_pairs = ", ".join([f"{key}={value}" for key, value in field_values.items() if value is not None])
     end = " &end\n"
     return start + kv_pairs + end

--- a/sdds/writer.py
+++ b/sdds/writer.py
@@ -45,11 +45,7 @@ def _write_header(sdds_file: SddsFile, outbytes: IO[bytes]) -> List[str]:
 
 
 def _sdds_def_as_str(definition: Union[Description, Definition, Data]) -> str:
-    start = definition.TAG + " "
-    field_values = {field.name: getattr(definition, field.name) for field in fields(definition)}
-    kv_pairs = ", ".join([f"{key}={value}" for key, value in field_values.items() if value is not None])
-    end = " &end\n"
-    return start + kv_pairs + end
+    return f"{definition.TAG} {definition.get_key_value_string()} &end\n"
 
 
 def _write_data(names: List[str], sdds_file: SddsFile, outbytes: IO[bytes]) -> None:

--- a/sdds/writer.py
+++ b/sdds/writer.py
@@ -7,6 +7,7 @@ It provides a high-level function to write SDDS files in different formats, and 
 """
 import pathlib
 import struct
+from dataclasses import fields
 from typing import IO, List, Union, Iterable, Tuple, Any
 import numpy as np
 from sdds.classes import (SddsFile, Column, Parameter, Definition, Array, Data, Description,
@@ -45,13 +46,13 @@ def _write_header(sdds_file: SddsFile, outbytes: IO[bytes]) -> List[str]:
 
 def _sdds_def_as_str(definition: Union[Description, Definition, Data]) -> str:
     start = definition.TAG + " "
-    things = ", ".join([f"{key}={definition.__dict__[key]}"
-                        for key in definition.__dict__ if "__" not in key])
+    field_values = {field.name: getattr(definition, field.name)for field in fields(definition)}
+    kv_pairs = ", ".join([f"{key}={value}" for key, value in field_values.items() if value is not None])
     end = " &end\n"
-    return start + things + end
+    return start + kv_pairs + end
 
 
-def _write_data(names: List[str], sdds_file: SddsFile, outbytes: IO[bytes])-> None:
+def _write_data(names: List[str], sdds_file: SddsFile, outbytes: IO[bytes]) -> None:
     # row_count:
     outbytes.write(np.array(0, dtype=get_dtype_str("long")).tobytes())
     _write_parameters((sdds_file[name] for name in names

--- a/tests/test_sdds.py
+++ b/tests/test_sdds.py
@@ -89,18 +89,18 @@ class TestReadFunctions:
 
     def test_read_header(self):
         test_head = b"""
-SDDS1
-!# big-endian
-&parameter name=acqStamp, type=double, &end
-&parameter name=nbOfCapTurns, type=long, &end
-&array name=horPositionsConcentratedAndSorted, type=float, &end
-&array
-    name=verBunchId,
-    type=long,
-    field_length=3,
-&end
-&data mode=binary, &end
-"""
+        SDDS1
+        !# big-endian
+        &parameter name=acqStamp, type=double, &end
+        &parameter name=nbOfCapTurns, type=long, &end
+        &array name=horPositionsConcentratedAndSorted, type=float, &end
+        &array
+            name=verBunchId,
+            type=long,
+            field_length=3,
+        &end
+        &data mode=binary, &end
+        """
         test_data = {"acqStamp": "double", "nbOfCapTurns": "long",
                      "horPositionsConcentratedAndSorted": "float",
                      "verBunchId": "long"}
@@ -112,19 +112,19 @@ SDDS1
 
     def test_read_header_optionals(self):
         test_head = b"""
-    SDDS1
-    !# little-endian
-    &description text="Momentum aperture search", contents="momentum aperture", &end
-    &parameter name=Step, type=long, &end
-    &parameter name=SVNVersion, description="SVN version number", type=string, fixed_value=28096M, &end
-    &column name=ElementName, type=string,  &end
-    &column name=s, units=m, type=double,  &end
-    &column name=ElementType, type=string,  &end
-    &column name=ElementOccurence, type=long,  &end
-    &column name=deltaPositiveFound, type=short,  &end
-    &column name=deltaPositive, symbol="$gd$R$bpos$n", type=double,  &end
-    &data mode=binary, &end
-    """
+        SDDS1
+        !# little-endian
+        &description text="Momentum aperture search", contents="momentum aperture", &end
+        &parameter name=Step, type=long, &end
+        &parameter name=SVNVersion, description="SVN version number", type=string, fixed_value=28096M, &end
+        &column name=ElementName, type=string,  &end
+        &column name=s, units=m, type=double,  &end
+        &column name=ElementType, type=string,  &end
+        &column name=ElementOccurence, type=long,  &end
+        &column name=deltaPositiveFound, type=short,  &end
+        &column name=deltaPositive, symbol="$gd$R$bpos$n", type=double,  &end
+        &data mode=binary, &end
+        """
         version, definitions, _, data = _read_header(io.BytesIO(test_head))
 
 

--- a/tests/test_sdds.py
+++ b/tests/test_sdds.py
@@ -110,6 +110,23 @@ SDDS1
         for definition in definitions:
             assert definition.type == test_data[definition.name]
 
+    def test_read_header_optionals(self):
+        test_head = b"""
+    SDDS1
+    !# little-endian
+    &description text="Momentum aperture search", contents="momentum aperture", &end
+    &parameter name=Step, type=long, &end
+    &parameter name=SVNVersion, description="SVN version number", type=string, fixed_value=28096M, &end
+    &column name=ElementName, type=string,  &end
+    &column name=s, units=m, type=double,  &end
+    &column name=ElementType, type=string,  &end
+    &column name=ElementOccurence, type=long,  &end
+    &column name=deltaPositiveFound, type=short,  &end
+    &column name=deltaPositive, symbol="$gd$R$bpos$n", type=double,  &end
+    &data mode=binary, &end
+    """
+        version, definitions, _, data = _read_header(io.BytesIO(test_head))
+
 
 def test_def_as_dict():
     test_str = (b"test1=value1,  test2= value2, \n"

--- a/tests/test_sdds.py
+++ b/tests/test_sdds.py
@@ -140,6 +140,7 @@ class TestReadFunctions:
         # check
         for entry in definitions:
             check_dict = to_check[entry.name]
+            assert entry.__class__.__name__ == check_dict.pop("class")
             for key, value in check_dict.items():
                 assert getattr(entry, key) == value
 
@@ -289,6 +290,7 @@ def _write_read_header():
 
 def _header_from_dict(d: Dict[str, Dict[str, str]]) -> str:
     """ Build a quick header from given dict. """
+    d = {k: v.copy() for k, v in d.items()}
     return ", &end\n".join(  # join lines
         f"&{v.pop('class').lower()} name={k}, type={v.pop('type')}" +
         (", " + ", ".join(f"{vk}={vv}" for vk, vv in v.items()) if v else "")

--- a/tests/test_sdds.py
+++ b/tests/test_sdds.py
@@ -139,12 +139,12 @@ def test_def_as_dict():
 
 
 def test_sort_defs():
-    param1 = Parameter(name="param1", type_="long")
-    param2 = Parameter(name="param2", type_="long")
-    array1 = Array(name="array1", type_="long")
-    array2 = Array(name="array2", type_="long")
-    col1 = Column(name="col1", type_="long")
-    col2 = Column(name="col2", type_="long")
+    param1 = Parameter(name="param1", type="long")
+    param2 = Parameter(name="param2", type="long")
+    array1 = Array(name="array1", type="long")
+    array2 = Array(name="array2", type="long")
+    col1 = Column(name="col1", type="long")
+    col2 = Column(name="col2", type="long")
     unsorted = [array1, col1, param1, param2, array2, col2]
     sorted_ = [param1, param2, array1, array2, col1, col2]
     assert sorted_ == _sort_definitions(unsorted)
@@ -212,8 +212,8 @@ class TestClasses:
         with pytest.raises(ValueError) as e:
             SddsFile(
                 version="SDDS1", description=None,
-                definitions_list=[Parameter(name="test", type_="int"),
-                                  Parameter(name="test", type_="str")],
+                definitions_list=[Parameter(name="test", type="int"),
+                                  Parameter(name="test", type="str")],
                 values_list=[1, "hello"],
             )
         assert "Duplicated" in str(e)
@@ -223,7 +223,7 @@ class TestClasses:
         assert "SDDS-File" in repr(sdds)
         assert "SDDS-File" in str(sdds)
 
-        definition = Definition(name="mydef", type_="mytype")
+        definition = Definition(name="mydef", type="mytype")
         assert "Definition" in repr(definition)
         assert "mydef" in repr(definition)
         assert "Definition" in str(definition)
@@ -231,7 +231,7 @@ class TestClasses:
         assert "mytype" in str(definition)
         assert "no tag" in str(definition)
 
-        array = Array(name="mydef", type_="mytype")
+        array = Array(name="mydef", type="mytype")
         assert "Array" in repr(array)
         assert "Array" in str(array)
         assert "&array" in str(array)


### PR DESCRIPTION
Fixes the typehints issue by using `dataclass` and `fields` instead of normal classes and browsing through their `__dict__`.
This changes two things:
- Arrays now have `field_length` and `dimensions` set to `None` (instead of `0`, and `1` respectively) so these parameter are not written out (which they were not in previous versions either, despite defaulting to these values. I am not sure, why they didn't show up in the dict)
- in the past `type_` was the kwarg given to the class and `.type` then its argument. Now all is `type` (because I don't wan't to re-map in the `post_init`. If this is not liked, we can discuss.

Also:
- added the test that @lmalina wrote in his branch (that never got a PR :( )