### PR TITLE
fixes #49 and black format, fixed typing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SDDS-Files Changelog
 
+## Version 0.4.1
+- Writing empty arrays doesn't throw errors
+
 ## Version 0.4
 - Added:
     - Support for reading gzipped compressed file and arbitrary compression formats if the opener abstraction is provided.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 import pathlib
-import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -110,14 +109,14 @@ todo_include_todos = True
 html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
-    'collapse_navigation': False,
-    'display_version': True,
-    'logo_only': True,
-    'navigation_depth': 3,
+    "collapse_navigation": False,
+    "display_version": True,
+    "logo_only": True,
+    "navigation_depth": 3,
 }
 
-html_logo = '_static/img/omc_logo.svg'
-html_static_path = ['_static']
+html_logo = "_static/img/omc_logo.svg"
+html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
 smartquotes_action = "qe"  # renders only quotes and ellipses (...) but not dashes (option: D)

--- a/sdds/__init__.py
+++ b/sdds/__init__.py
@@ -16,4 +16,4 @@ read = read_sdds
 write = write_sdds
 
 
-__all__ = [read, SddsFile, write, __version__]
+__all__ = ["read", "SddsFile", "write", "__version__"]

--- a/sdds/__init__.py
+++ b/sdds/__init__.py
@@ -6,7 +6,7 @@ from sdds.writer import write_sdds
 __title__ = "sdds"
 __description__ = "SDDS file handling."
 __url__ = "https://github.com/pylhc/sdds"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -70,7 +70,7 @@ class Description:
         return "<SDDS Description Container>"
 
     def get_key_value_string(self) -> str:
-        warnings.warn("no implemented yet")
+        warnings.warn("not implemented yet")
         return ""
 
 
@@ -243,7 +243,7 @@ class Data:
         return f"<SDDS {self.mode} Data Container>"
 
     def get_key_value_string(self) -> str:
-        warnings.warn("no implemented yet")
+        warnings.warn("not implemented yet")
         return ""
 
 

--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -6,9 +6,10 @@ This module holds classes to handle different namelist commands in an SDDS file.
 Implementation are based on documentation at:
 https://ops.aps.anl.gov/manuals/SDDStoolkit/SDDStoolkitsu2.html
 """
-from typing import Any, Tuple, List, Iterator, Optional, Dict, ClassVar
-from dataclasses import dataclass, fields
 import logging
+import warnings
+from dataclasses import dataclass, fields
+from typing import Any, ClassVar, Dict, Iterator, List, Optional, Tuple
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,26 +21,30 @@ LOGGER = logging.getLogger(__name__)
 ENCODING = "utf-8"
 ENCODING_LEN = 1
 
-ENDIAN = {'little': '<', 'big': '>'}
+ENDIAN = {"little": "<", "big": ">"}
 
-NUMTYPES = {"float": "f", "double": "d", "short": "i2",
-            "long": "i4", "llong": "i8", "char": "i1", "boolean": "i1",
-            "string": "s"}
-NUMTYPES_SIZES = {"float": 4, "double": 8, "short": 2,
-                  "long": 4, "llong": 8, "char": 1, "boolean": 1}
-NUMTYPES_CAST = {"float": float, "double": float, "short": int,
-                 "long": int, "llong": int, "char": str, "boolean": int}
+NUMTYPES = {
+    "float": "f",
+    "double": "d",
+    "short": "i2",
+    "long": "i4",
+    "llong": "i8",
+    "char": "i1",
+    "boolean": "i1",
+    "string": "s",
+}
+NUMTYPES_SIZES = {"float": 4, "double": 8, "short": 2, "long": 4, "llong": 8, "char": 1, "boolean": 1}
+NUMTYPES_CAST = {"float": float, "double": float, "short": int, "long": int, "llong": int, "char": str, "boolean": int}
 
 
-def get_dtype_str(type_: str, endianness: str = 'big', length: int = None):
-    if length is None:
-        length = ''
-    return f"{ENDIAN[endianness]}{length}{NUMTYPES[type_]}"
+def get_dtype_str(type_: str, endianness: str = "big", length: Optional[int] = None):
+    return f"{ENDIAN[endianness]}{length if length is not None else ''}{NUMTYPES[type_]}"
 
 
 ##############################################################################
 #  Classes
 ##############################################################################
+
 
 @dataclass
 class Description:
@@ -51,17 +56,22 @@ class Description:
     contents, is intended to formally specify the type of data stored in a data set. Most
     frequently, the contents field is used to record the name of the program that created or most
     recently modified the file.
-    
+
     Fields:
         text (str): Optional. Informal description intended for humans.
         contents (str): Optional. Formal specification of the type of data stored in a data set.
     """
+
     text: Optional[str] = None
     contents: Optional[str] = None
     TAG: ClassVar[str] = "&description"
 
     def __repr__(self):
-        return f"<SDDS Description Container>"
+        return "<SDDS Description Container>"
+
+    def get_key_value_string(self) -> str:
+        warnings.warn("no implemented yet")
+        return ""
 
 
 @dataclass
@@ -75,10 +85,11 @@ class Include:
     Fields:
         filename (str): Name of the file to be read containing header lines.
     """
+
     filename: str
 
     def __repr__(self):
-        return f"<SDDS Include Container>"
+        return "<SDDS Include Container>"
 
     def __str__(self):
         return f"Include: {self.filename:s}"
@@ -106,12 +117,14 @@ class Definition:
                       (e.g. for ASCII in SDDS or other formats). NOT IMPLEMENTED!
 
     """
+
     name: str
     type: str
     symbol: Optional[str] = None
     units: Optional[str] = None
     description: Optional[str] = None
     format: Optional[str] = None
+    TAG: ClassVar[Optional[str]] = None
 
     def __post_init__(self):
         # Fix types (probably strings from reading files) by using the type-hints
@@ -130,20 +143,19 @@ class Definition:
                     continue
 
                 # find the proper type from type-hint:
-                hinted_type = next(t for t in hinted_type.__args__
-                                   if not isinstance(t, type(None)))
+                hinted_type = next(t for t in hinted_type.__args__ if not isinstance(t, type(None)))
 
             if isinstance(value, hinted_type):
                 # all is fine
                 continue
 
-            LOGGER.debug(f"converting {field.name}: "
-                         f"{type(value).__name__} -> {hinted_type.__name__}")
+            LOGGER.debug(f"converting {field.name}: " f"{type(value).__name__} -> {hinted_type.__name__}")
             setattr(self, field.name, hinted_type(value))
 
     def get_key_value_string(self) -> str:
-        """ Return a string with comma separated key=value pairs.
-            Hint: `ClassVars` (like ``TAG``) are ignored in `fields`.
+        """Return a string with comma separated key=value pairs.
+
+        Hint: `ClassVars` (like ``TAG``) are ignored in `fields`.
         """
         field_values = {field.name: getattr(self, field.name) for field in fields(self)}
         return ", ".join([f"{key}={value}" for key, value in field_values.items() if value is not None])
@@ -152,7 +164,7 @@ class Definition:
         return f"<SDDS {self.__class__.__name__} '{self.name}'>"
 
     def __str__(self):
-        return f"<{self.__class__.__name__} ({getattr(self, 'TAG', 'no tag')})> {self.get_key_value_string()}"
+        return f"<{self.__class__.__name__} ({self.TAG or 'no tag'})> {self.get_key_value_string()}"
 
 
 @dataclass
@@ -163,6 +175,7 @@ class Column(Definition):
     This optional command defines a column that will appear in the tabular data section of each
     data page.
     """
+
     TAG: ClassVar[str] = "&column"
 
 
@@ -181,6 +194,7 @@ class Parameter(Definition):
                            This feature is for convenience only;
                            the parameter thus defined is treated like any other.
     """
+
     TAG: ClassVar[str] = "&parameter"
     fixed_value: Optional[str] = None
 
@@ -203,6 +217,7 @@ class Array(Definition):
         dimensions (int): Optional. Gives the number of dimensions in the array.
                           If not given, defaults to ``1`` upon reading.
     """
+
     TAG: ClassVar[str] = "&array"
     field_length: Optional[int] = None
     group_name: Optional[str] = None
@@ -220,11 +235,16 @@ class Data:
     Fields:
         mode (str): File/Data mode. Either “binary” or "ascii".
     """
+
     mode: str
     TAG: ClassVar[str] = "&data"
 
     def __repr__(self):
         return f"<SDDS {self.mode} Data Container>"
+
+    def get_key_value_string(self) -> str:
+        warnings.warn("no implemented yet")
+        return ""
 
 
 class SddsFile:
@@ -257,14 +277,19 @@ class SddsFile:
         values (dict[str, Any]): Values of the data, mapped to their name.
 
     """
+
     version: str  # This should always be "SDDS1"
     description: Optional[Description]
     definitions: Dict[str, Definition]
     values: Dict[str, Any]
 
-    def __init__(self, version: str, description: Optional[Description],
-                 definitions_list: List[Definition],
-                 values_list: List[Any]) -> None:
+    def __init__(
+        self,
+        version: str,
+        description: Optional[Description],
+        definitions_list: List[Definition],
+        values_list: List[Any],
+    ) -> None:
         self.version = version
 
         name_list = [definition.name for definition in definitions_list]
@@ -273,8 +298,7 @@ class SddsFile:
 
         self.description = description
         self.definitions = {definition.name: definition for definition in definitions_list}
-        self.values = {definition.name: value for definition, value
-                       in zip(definitions_list, values_list)}
+        self.values = {definition.name: value for definition, value in zip(definitions_list, values_list)}
 
     def __getitem__(self, name: str) -> Tuple[Definition, Any]:
         return self.definitions[name], self.values[name]
@@ -284,7 +308,7 @@ class SddsFile:
             yield self[def_name]
 
     def __repr__(self):
-        return f"<SDDS-File Object>"
+        return "<SDDS-File Object>"
 
     def __str__(self):
         return f"SDDS-File ({self.version})"  # TODO make something nice

--- a/sdds/reader.py
+++ b/sdds/reader.py
@@ -6,21 +6,30 @@ This module contains the reading functionality of ``sdds``.
 It provides a high-level function to read SDDS files in different formats, and a series of helpers.
 """
 import gzip
-import io
 import os
 import pathlib
 import struct
 import sys
 from collections.abc import Callable
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import AbstractContextManager
 from functools import partial
 from typing import IO, Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
-from sdds.classes import (ENCODING, NUMTYPES_CAST, NUMTYPES_SIZES, Array,
-                          Column, Data, Definition, Description, Parameter,
-                          SddsFile, get_dtype_str)
+from sdds.classes import (
+    ENCODING,
+    NUMTYPES_CAST,
+    NUMTYPES_SIZES,
+    Array,
+    Column,
+    Data,
+    Definition,
+    Description,
+    Parameter,
+    SddsFile,
+    get_dtype_str,
+)
 
 # ----- Providing Opener Abstractions for the Reader ----- #
 
@@ -31,7 +40,7 @@ from sdds.classes import (ENCODING, NUMTYPES_CAST, NUMTYPES_SIZES, Array,
 if sys.version_info < (3, 9, 0):  # we're running on 3.8, which is our lowest supported
     OpenerType = Callable
 else:
-    OpenerType = Callable[[os.PathLike], AbstractContextManager[io.BufferedIOBase]]
+    OpenerType = Callable[[os.PathLike], AbstractContextManager[IO]]
 
 binary_open = partial(open, mode="rb")  # default opening mode, simple sdds files
 gzip_open = partial(gzip.open, mode="rb")  # for gzip-compressed sdds files
@@ -39,7 +48,12 @@ gzip_open = partial(gzip.open, mode="rb")  # for gzip-compressed sdds files
 
 # ----- Reader Function ----- #
 
-def read_sdds(file_path: Union[pathlib.Path, str], endianness: str = None, opener: OpenerType = binary_open) -> SddsFile:
+
+def read_sdds(
+    file_path: Union[pathlib.Path, str],
+    endianness: Optional[str] = None,
+    opener: OpenerType = binary_open,
+) -> SddsFile:
     """
     Reads an SDDS file from the specified ``file_path``.
 
@@ -56,7 +70,7 @@ def read_sdds(file_path: Union[pathlib.Path, str], endianness: str = None, opene
 
     Returns:
         An `SddsFile` object containing the loaded data.
-    
+
     Examples:
 
         To read a typical file, one can use the default options:
@@ -105,23 +119,24 @@ def read_sdds(file_path: Union[pathlib.Path, str], endianness: str = None, opene
 # Common reading of header and data.
 ##############################################################################
 
-def _read_header(inbytes: IO[bytes]) -> Tuple[str, List[Definition], Optional[Description], Data]:
+
+def _read_header(
+    inbytes: IO[bytes],
+) -> Tuple[str, List[Definition], Optional[Description], Data]:
     word_gen = _gen_words(inbytes)
     version = next(word_gen)  # First token is the SDDS version
-    assert version == "SDDS1",\
-        "This module is compatible with SDDS v1 only... are there really other versions?"
+    assert version == "SDDS1", "This module is compatible with SDDS v1 only... are there really other versions?"
     definitions: List[Definition] = []
     description: Optional[Description] = None
     data: Optional[Data] = None
     for word in word_gen:
         def_dict: Dict[str, str] = _get_def_as_dict(word_gen)
         if word in (Column.TAG, Parameter.TAG, Array.TAG):
-            definitions.append({
-                Column.TAG: Column,
-                Parameter.TAG: Parameter,
-                Array.TAG: Array}[word](name=def_dict.pop("name"),
-                                        type=def_dict.pop("type"),
-                                        **def_dict))
+            definitions.append(
+                {Column.TAG: Column, Parameter.TAG: Parameter, Array.TAG: Array}[word](
+                    name=def_dict.pop("name"), type=def_dict.pop("type"), **def_dict
+                )
+            )
             continue
         if word == Description.TAG:
             if description is not None:
@@ -147,8 +162,7 @@ def _sort_definitions(orig_defs: List[Definition]) -> List[Definition]:
     According to the specification, parameters appear first in data pages then arrays
     and then columns. Inside each group they follow the order of appearance in the header.
     """
-    definitions: List[Definition] = [definition for definition in orig_defs
-                                     if isinstance(definition, Parameter)]
+    definitions: List[Definition] = [definition for definition in orig_defs if isinstance(definition, Parameter)]
     definitions.extend([definition for definition in orig_defs if isinstance(definition, Array)])
     definitions.extend([definition for definition in orig_defs if isinstance(definition, Column)])
     return definitions
@@ -167,12 +181,13 @@ def _read_data(data: Data, definitions: List[Definition], inbytes: IO[bytes], en
 # Binary data reading
 ##############################################################################
 
+
 def _read_data_binary(definitions: List[Definition], inbytes: IO[bytes], endianness: str) -> List[Any]:
     row_count: int = _read_bin_int(inbytes, endianness)  # First int in bin data
     functs_dict: Dict[Type[Definition], Callable] = {
         Parameter: _read_bin_param,
         Column: lambda x, y, z: _read_bin_column(x, y, z, row_count),
-        Array: _read_bin_array
+        Array: _read_bin_array,
     }
     return [functs_dict[definition.__class__](inbytes, definition, endianness) for definition in definitions]
 
@@ -188,9 +203,7 @@ def _read_bin_param(inbytes: IO[bytes], definition: Parameter, endianness: str) 
     if definition.type == "string":
         str_len: int = _read_bin_int(inbytes, endianness)
         return _read_string(inbytes, str_len, endianness)
-    return NUMTYPES_CAST[definition.type](
-        _read_bin_numeric(inbytes, definition.type, 1, endianness)
-    )
+    return NUMTYPES_CAST[definition.type](_read_bin_numeric(inbytes, definition.type, 1, endianness))
 
 
 def _read_bin_column(inbytes: IO[bytes], definition: Column, endianness: str, row_count: int):
@@ -202,9 +215,7 @@ def _read_bin_array(inbytes: IO[bytes], definition: Array, endianness: str) -> A
     dims, total_len = _read_bin_array_len(inbytes, definition.dimensions, endianness)
 
     if definition.type == "string":
-        len_type = {"u1": "char", "i2": "short"}.get(
-            getattr(definition, "modifier", None), "long"
-        )
+        len_type = {"u1": "char", "i2": "short"}.get(getattr(definition, "modifier", ""), "long")
         str_array = []
         for _ in range(total_len):
             str_len = int(_read_bin_numeric(inbytes, len_type, 1, endianness))
@@ -224,8 +235,10 @@ def _read_bin_array_len(inbytes: IO[bytes], num_dims: Optional[int], endianness:
 
 
 def _read_bin_numeric(inbytes: IO[bytes], type_: str, count: int, endianness: str) -> Any:
-    return np.frombuffer(inbytes.read(count * NUMTYPES_SIZES[type_]),
-                         dtype=np.dtype(get_dtype_str(type_, endianness)))
+    return np.frombuffer(
+        inbytes.read(count * NUMTYPES_SIZES[type_]),
+        dtype=np.dtype(get_dtype_str(type_, endianness)),
+    )
 
 
 def _read_bin_int(inbytes: IO[bytes], endianness: str) -> int:
@@ -242,6 +255,7 @@ def _read_string(inbytes: IO[bytes], str_len: int, endianness: str) -> str:
 # ASCII data reading
 ##############################################################################
 
+
 def _read_data_ascii(definitions: List[Definition], inbytes: IO[bytes]) -> List[Any]:
     def _ascii_generator(ascii_text):
         for line in ascii_text:
@@ -249,33 +263,26 @@ def _read_data_ascii(definitions: List[Definition], inbytes: IO[bytes]) -> List[
 
     # Convert bytes to ASCII, separate by lines and remove comments
     ascii_text = [chr(r) for r in inbytes.read()]
-    ascii_text = ''.join(ascii_text).split('\n')
-    ascii_text = [line for line in ascii_text if not line.startswith('!')]
+    ascii_text = "".join(ascii_text).split("\n")
+    ascii_text = [line for line in ascii_text if not line.startswith("!")]
 
     # Get the generator for the text
     ascii_gen = _ascii_generator(ascii_text)
 
-    # Dict of function to call for each type of tag: array, parameter
-    functs_dict = {Parameter: _read_ascii_parameter,
-                   Array: _read_ascii_array
-                   }
-
     # Iterate through every parameters and arrays in the file
-    data = []
+    data: List[Any] = []
     for definition in definitions:
-        def_tag = definition.__class__
-
         # Call the function handling the tag we're on
         # Change the current line according to the tag and dimensions
-        value = functs_dict[def_tag](ascii_gen, definition)
-        data.append(value)
+        if isinstance(definition, Parameter):
+            data.append(_read_ascii_parameter(ascii_gen, definition))
+        elif isinstance(definition, Array):
+            data.append(_read_ascii_array(ascii_gen, definition))
 
     return data
 
 
-def _read_ascii_parameter(ascii_gen: Generator[str, None, None],
-                          definition: Parameter) -> Union[str, int, float]:
-
+def _read_ascii_parameter(ascii_gen: Generator[str, None, None], definition: Parameter) -> Union[str, int, float]:
     # Check if we got fixed values, no need to read a line if that's the case
     if definition.fixed_value is not None:
         if definition.type == "string":
@@ -295,33 +302,31 @@ def _read_ascii_parameter(ascii_gen: Generator[str, None, None],
     raise TypeError(f"Type {definition.type} for Parameter unsupported")
 
 
-def _read_ascii_array(ascii_gen: Generator[str, None, None],
-                      definition: Array) -> np.ndarray:
-
+def _read_ascii_array(ascii_gen: Generator[str, None, None], definition: Array) -> np.ndarray:
     # Get the number of elements per dimension
-    dimensions = next(ascii_gen).split()
-    dimensions = np.array(dimensions, dtype="int")
+    dimensions = np.array(next(ascii_gen).split(), dtype="int")
 
     # Get all the data given by the dimensions
-    data = []
+    data: List[str] = []
     while len(data) != np.prod(dimensions):
         # The values on each line are split by a space
-        data += next(ascii_gen).strip().split(' ')
+        data += next(ascii_gen).strip().split(" ")
 
     # Cast every object to the correct type
-    if definition.type != 'string':
+    if definition.type != "string":
         data = list(map(NUMTYPES_CAST[definition.type], data))
 
     # Convert to np.array so that it can be reshaped to reflect the dimensions
-    data = np.array(data)
-    data = data.reshape(dimensions)
+    npdata = np.array(data)
+    npdata = npdata.reshape(dimensions)
 
-    return data
+    return npdata
 
 
 ##############################################################################
 # Helper generators to consume the input bytes
 ##############################################################################
+
 
 def _get_endianness(inbytes: IO[bytes]) -> str:
     """Tries to determine endianness from file-comments.
@@ -337,7 +342,7 @@ def _get_endianness(inbytes: IO[bytes]) -> str:
         if line.strip() == "!# little-endian":
             endianness = "little"
             break
-    inbytes.seek(0)   # return back to beginning of file
+    inbytes.seek(0)  # return back to beginning of file
     return endianness
 
 
@@ -364,7 +369,6 @@ def _get_def_as_dict(word_gen: Generator[str, None, None]) -> Dict[str, str]:
         if word.strip() == "&end":
             recomposed: str = " ".join(raw_str)
             parts = [assign for assign in recomposed.split(",") if assign]
-            return {key.strip(): value.strip() for (key, value) in
-                    [assign.split("=") for assign in parts]}
+            return {key.strip(): value.strip() for (key, value) in [assign.split("=") for assign in parts]}
         raw_str.append(word.strip())
     raise ValueError("EOF found while looking for &end tag.")

--- a/sdds/reader.py
+++ b/sdds/reader.py
@@ -17,19 +17,9 @@ from typing import IO, Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
-from sdds.classes import (
-    ENCODING,
-    NUMTYPES_CAST,
-    NUMTYPES_SIZES,
-    Array,
-    Column,
-    Data,
-    Definition,
-    Description,
-    Parameter,
-    SddsFile,
-    get_dtype_str,
-)
+from sdds.classes import (ENCODING, NUMTYPES_CAST, NUMTYPES_SIZES, Array,
+                          Column, Data, Definition, Description, Parameter,
+                          SddsFile, get_dtype_str)
 
 # ----- Providing Opener Abstractions for the Reader ----- #
 
@@ -203,7 +193,7 @@ def _read_bin_param(inbytes: IO[bytes], definition: Parameter, endianness: str) 
     if definition.type == "string":
         str_len: int = _read_bin_int(inbytes, endianness)
         return _read_string(inbytes, str_len, endianness)
-    return NUMTYPES_CAST[definition.type](_read_bin_numeric(inbytes, definition.type, 1, endianness))
+    return NUMTYPES_CAST[definition.type](_read_bin_numeric(inbytes, definition.type, 1, endianness)[0])
 
 
 def _read_bin_column(inbytes: IO[bytes], definition: Column, endianness: str, row_count: int):
@@ -218,7 +208,7 @@ def _read_bin_array(inbytes: IO[bytes], definition: Array, endianness: str) -> A
         len_type = {"u1": "char", "i2": "short"}.get(getattr(definition, "modifier", ""), "long")
         str_array = []
         for _ in range(total_len):
-            str_len = int(_read_bin_numeric(inbytes, len_type, 1, endianness))
+            str_len = int(_read_bin_numeric(inbytes, len_type, 1, endianness)[0])
             str_array.append(_read_string(inbytes, str_len, endianness))
         return str_array
 
@@ -242,7 +232,7 @@ def _read_bin_numeric(inbytes: IO[bytes], type_: str, count: int, endianness: st
 
 
 def _read_bin_int(inbytes: IO[bytes], endianness: str) -> int:
-    return int(_read_bin_numeric(inbytes, "long", 1, endianness))
+    return int(_read_bin_numeric(inbytes, "long", 1, endianness)[0])
 
 
 def _read_string(inbytes: IO[bytes], str_len: int, endianness: str) -> str:

--- a/sdds/writer.py
+++ b/sdds/writer.py
@@ -55,16 +55,16 @@ def _write_data(names: List[str], sdds_file: SddsFile, outbytes: IO[bytes]) -> N
     def __getitem__(self, name: str) -> Tuple[Definition, Any]:
         return self.definitions[name], self.values[name]
 
-    parameters: List[Any] = []
-    arrays: List[Any] = []
-    columns: List[Any] = []
+    parameters: List[Tuple[Parameter, Any]] = []
+    arrays: List[Tuple[Array, Any]] = []
+    columns: List[Tuple[Column, Any]] = []
     for name in names:
         if isinstance(sdds_file[name][0], Parameter):
-            parameters.append(sdds_file[name])
+            parameters.append(sdds_file[name])  # type: ignore
         elif isinstance(sdds_file[name][0], Array):
-            arrays.append(sdds_file[name])
+            arrays.append(sdds_file[name])  # type: ignore
         elif isinstance(sdds_file[name][0], Column):
-            columns.append(sdds_file[name])
+            columns.append(sdds_file[name])  # type: ignore
     _write_parameters(parameters, outbytes)
     _write_arrays(arrays, outbytes)
     _write_columns(columns, outbytes)

--- a/sdds/writer.py
+++ b/sdds/writer.py
@@ -52,9 +52,6 @@ def _write_data(names: List[str], sdds_file: SddsFile, outbytes: IO[bytes]) -> N
     # row_count:
     outbytes.write(np.array(0, dtype=get_dtype_str("long")).tobytes())
 
-    def __getitem__(self, name: str) -> Tuple[Definition, Any]:
-        return self.definitions[name], self.values[name]
-
     parameters: List[Tuple[Parameter, Any]] = []
     arrays: List[Tuple[Array, Any]] = []
     columns: List[Tuple[Column, Any]] = []

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ EXTRA_DEPENDENCIES = {
     "test": ["pytest>=5.2", "pytest-cov>=2.6", "attrs>=19.2.0"],
     "doc": ["sphinx", "sphinx_rtd_theme"],
 }
-EXTRA_DEPENDENCIES.update(
-    {"all": [elem for list_ in EXTRA_DEPENDENCIES.values() for elem in list_]}
-)
+EXTRA_DEPENDENCIES.update({"all": [elem for list_ in EXTRA_DEPENDENCIES.values() for elem in list_]})
 
 
 setuptools.setup(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 # ignore numpy warnings, see:
 # https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility
 import warnings
+
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")


### PR DESCRIPTION
- I fixed the "get started" issue :-) 

- I use pyright and ruff for code linting and formatting. I changed a few things in the code, so it adheres to the standards applied by these tools. Most of the changes are just format, but the linter also found minor errors like this (`__all__` should contain names not the objects):

```
-__all__ = [read, SddsFile, write, __version__]
+__all__ = ["read", "SddsFile", "write", "__version__"]
```
- If you want to use other standards, I recommend using [poetry](https://python-poetry.org/) and a `pyproject.toml`. If you want to, I can add it to the repo. 