### PR TITLE
Rename `format` to `format_string` in `Description` as per SDDS definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,44 @@
 # SDDS-Files Changelog
 
+## Version 0.4.2
+
+- Using `format_string` instead of `format` in `Definition` class.
+
 ## Version 0.4.1
+
 - Writing empty arrays doesn't throw errors
 
 ## Version 0.4
+
 - Added:
-    - Support for reading gzipped compressed file and arbitrary compression formats if the opener abstraction is provided.
+  - Support for reading gzipped compressed file and arbitrary compression formats if the opener abstraction is provided.
 
 ## Version 0.3
+
 - Added:
-    - little endian support.
-    - manual endian selection for reader.
-    - string and representation for classes
+  - little endian support.
+  - manual endian selection for reader.
+  - string and representation for classes
 
 ## Version 0.2
+
 - Added:
-    - Support for ascii files.
-    - Support for `pathlib.Path` objects in read and write operations.
+  - Support for ascii files.
+  - Support for `pathlib.Path` objects in read and write operations.
 
 ## Version 0.1.2 and Version 0.1.3
- - Fixed:
-   - From relative to absolute imports (IMPORTANT FIX!!)
+
+- Fixed:
+  - From relative to absolute imports (IMPORTANT FIX!!)
 
 ## Version 0.1.1
- - Fixed: 
-    - Imports (for doc)
-    
- - Added: 
-    - Versioning
-    - Changelog
+
+- Fixed:
+  - Imports (for doc)
+- Added:
+  - Versioning
+  - Changelog
 
 ## Version 0.1.0
- - Initial Release
+
+- Initial Release

--- a/sdds/__init__.py
+++ b/sdds/__init__.py
@@ -6,7 +6,7 @@ from sdds.writer import write_sdds
 __title__ = "sdds"
 __description__ = "SDDS file handling."
 __url__ = "https://github.com/pylhc/sdds"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -113,8 +113,8 @@ class Definition:
                       to produce Greek or mathematical characters.
         units (str): Optional. Allows specification of the units of the parameter.
         description (str): Optional.  Provides for an informal description of the parameter.
-        format (str): Optional. Specification of the print format string to be used to print the data
-                      (e.g. for ASCII in SDDS or other formats).
+        format_string (str): Optional. Specification of the print format string to be used to print the data
+                             (e.g. for ASCII in SDDS or other formats).
 
     """
 

--- a/sdds/classes.py
+++ b/sdds/classes.py
@@ -114,7 +114,7 @@ class Definition:
         units (str): Optional. Allows specification of the units of the parameter.
         description (str): Optional.  Provides for an informal description of the parameter.
         format (str): Optional. Specification of the print format string to be used to print the data
-                      (e.g. for ASCII in SDDS or other formats). NOT IMPLEMENTED!
+                      (e.g. for ASCII in SDDS or other formats).
 
     """
 
@@ -123,7 +123,7 @@ class Definition:
     symbol: Optional[str] = None
     units: Optional[str] = None
     description: Optional[str] = None
-    format: Optional[str] = None
+    format_string: Optional[str] = None
     TAG: ClassVar[Optional[str]] = None
 
     def __post_init__(self):


### PR DESCRIPTION
Fixes #62 