### PR TITLE
Maintenance and coverage config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SDDS-Files Changelog
 
+## Version 0.4.3
+
+- Dropped support for `Python 3.9`.
+
 ## Version 0.4.2
 
 - Using `format_string` instead of `format` in `Definition` class.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # SDDS
-[![Cron Testing](https://github.com/pylhc/sdds/workflows/Cron%20Testing/badge.svg)](https://github.com/pylhc/sdds/actions?query=workflow%3A%22Cron+Testing%22)
-[![Code Climate coverage](https://img.shields.io/codeclimate/coverage/pylhc/sdds.svg?style=popout)](https://codeclimate.com/github/pylhc/sdds)
-[![Code Climate maintainability (percentage)](https://img.shields.io/codeclimate/maintainability-percentage/pylhc/sdds.svg?style=popout)](https://codeclimate.com/github/pylhc/sdds)
-<!-- [![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/sdds.svg?style=popout)](https://github.com/pylhc/sdds/) -->
+
+[![Tests](https://github.com/pylhc/sdds/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/pylhc/sdds/actions/workflows/coverage.yml)
+[![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/sdds.svg?style=popout)](https://github.com/pylhc/sdds/)
 [![PyPI Version](https://img.shields.io/pypi/v/sdds?label=PyPI&logo=pypi)](https://pypi.org/project/sdds/)
 [![GitHub release](https://img.shields.io/github/v/release/pylhc/sdds?logo=github)](https://github.com/pylhc/sdds/)
 [![Conda-forge Version](https://img.shields.io/conda/vn/conda-forge/sdds?color=orange&logo=anaconda)](https://anaconda.org/conda-forge/sdds)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5705820.svg)](https://doi.org/10.5281/zenodo.5705820)
 
 This package provides reading and writing functionality for [**self describing data sets (sdds)**](https://ops.aps.anl.gov/SDDSIntroTalk/slides.html) files.
-On the python side, the data is stored in a class structure with attributes corresponding to the sdds-format itself (see [sdds-format](https://ops.aps.anl.gov/manuals/SDDStoolkit/SDDStoolkitsu2.html)). 
+On the python side, the data is stored in a class structure with attributes corresponding to the sdds-format itself (see [sdds-format](https://ops.aps.anl.gov/manuals/SDDStoolkit/SDDStoolkitsu2.html)).
 
 See the [API documentation](https://pylhc.github.io/sdds/) for details.
 
 ## Installing
 
 Installation is easily done via `pip`:
+
 ```bash
 python -m pip install sdds
 ```
 
 One can also install in a `conda` environment via the `conda-forge` channel with:
+
 ```bash
 conda install -c conda-forge sdds
 ```
@@ -40,7 +41,7 @@ By default the endianness (byte order) of the file is determined either by
 a comment `!# little-endian` or `!# big-endian` in the header of the file.
 If this comment is not found, the endianness of the running machine is assumed.
 
-One can force a certain kind of endianness to the reader by supplying it to 
+One can force a certain kind of endianness to the reader by supplying it to
 the read function:
 
 ```python
@@ -50,9 +51,9 @@ sdds_data = sdds.read("path_to_input_with_big_endian.sdds", endianness="big")
 sdds_data = sdds.read("path_to_input_with_little_endian.sdds", endianness="little")
 ```
 
-Be aware that `sdds.write` will always write the file in big-endian order and 
+Be aware that `sdds.write` will always write the file in big-endian order and
 will also leave a comment in the file, so that the reader can determine the
-endianness and there is no need to supply it when reading 
+endianness and there is no need to supply it when reading
 a file written by this package.
 
 ## Known Issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ changelog = "https://github.com/pylhc/sdds/blob/master/CHANGELOG.md"
 
 # ----- Testing ----- #
 
+[tool.pytest.ini_options]
+addopts = "--cov-report=xml --cov-report term-missing --cov-config=pyproject.toml --cov=sdds"
+testpaths = ["tests"]
+
 [tool.coverage.run]
 source = ["sdds/"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 ]
 license = "MIT"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 keywords = [
   "SDDS",
@@ -36,10 +36,11 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -74,17 +75,16 @@ changelog = "https://github.com/pylhc/sdds/blob/master/CHANGELOG.md"
 # ----- Testing ----- #
 
 [tool.pytest.ini_options]
-addopts = "--cov-report=xml --cov-report term-missing --cov-config=pyproject.toml --cov=sdds"
-testpaths = ["tests"]
+addopts = [
+    "--import-mode=importlib",
+]
 
 [tool.coverage.run]
-source = ["sdds/"]
+relative_files = true
 
 [tool.coverage.report]
-precision = 2
-ignore_errors = true
 exclude_also = [
-  "if TYPE_CHECKING:",  # do not count if TYPE_CHECKING block imports (ignored at runtime) for coverage
+  "if TYPE_CHECKING:",  # do not count type checking imports (ignored at runtime) for coverage
   "except ImportError:",  # do not count missing optional dependencies set to None, we monkeypatch and test that
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,19 @@ repository = "https://github.com/pylhc/sdds"
 documentation = "https://pylhc.github.io/sdds/"
 changelog = "https://github.com/pylhc/sdds/blob/master/CHANGELOG.md"
 
+# ----- Testing ----- #
+
+[tool.coverage.run]
+source = ["sdds/"]
+
+[tool.coverage.report]
+precision = 2
+ignore_errors = true
+exclude_also = [
+  "if TYPE_CHECKING:",  # do not count if TYPE_CHECKING block imports (ignored at runtime) for coverage
+  "except ImportError:",  # do not count missing optional dependencies set to None, we monkeypatch and test that
+]
+
 # ----- Dev Tools Configuration ----- #
 
 [tool.ruff]

--- a/sdds/__init__.py
+++ b/sdds/__init__.py
@@ -7,7 +7,7 @@ from sdds.writer import write_sdds
 __title__ = "sdds"
 __description__ = "SDDS file handling."
 __url__ = "https://github.com/pylhc/sdds"
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"


### PR DESCRIPTION
Drop Python 3.9, add coverage config options (as done in `omc3`), remove CodeClimate and update coverage badge on readme, some markdown linting.

Tests also good on 3.14 on macOS.
